### PR TITLE
Handle "Inappropriate ioctl for device" Error on macOS PyCharm Launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+

--- a/main.py
+++ b/main.py
@@ -147,26 +147,32 @@ def get_sort_type() -> str:
 
 
 def main() -> None:
-    art = text2art(text="LAYERZERO  STATS", font="standart")
-    print(colored(art,'light_blue'))
-    art = text2art(text="from NFTCOPILOT.COM", font="cybermedum")
-    print(colored(art,'light_cyan'))
-    print(colored('Автор: t.me/cryptogovnozavod\n','light_cyan'))
+    try:
+        art = text2art(text="LAYERZERO  STATS", font="standart")
+        print(colored(art,'light_blue'))
+        art = text2art(text="from NFTCOPILOT.COM", font="cybermedum")
+        print(colored(art,'light_cyan'))
+        print(colored('Автор: t.me/cryptogovnozavod\n','light_cyan'))
 
-    while True:
-        action = get_action()
+        while True:
+            action = get_action()
 
-        match action:
-            case 'Получить статистику и составить Excel таблицу':
-                sort_type = get_sort_type()
-                worker(sort_type)
-            case 'Выход':
-                exit()
-            case _:
-                pass
+            match action:
+                case 'Получить статистику и составить Excel таблицу':
+                    sort_type = get_sort_type()
+                    worker(sort_type)
+                case 'Выход':
+                    exit()
+                case _:
+                    pass
+    except Exception as e:
+        if 'Inappropriate ioctl for device' in str(e):
+            print(colored('\n\nЗапустите программу в терминале! python3 main.py\n\n','red'))
+
 
 
 if (__name__ == '__main__'):
+    print(1)
 
     with open(file_wallets, 'r') as file:
         wallets = [row.split(":")[0].strip() if ":" in row else row.strip() for row in file]

--- a/main.py
+++ b/main.py
@@ -172,7 +172,6 @@ def main() -> None:
 
 
 if (__name__ == '__main__'):
-    print(1)
 
     with open(file_wallets, 'r') as file:
         wallets = [row.split(":")[0].strip() if ":" in row else row.strip() for row in file]


### PR DESCRIPTION
When launching the application from PyCharm on macOS, the error "Inappropriate ioctl for device" occurs. To address this issue, I've implemented a notification mechanism within the error handling logic. Specifically, I enclosed the entire content of the main function in a try-except block. In the case of an exception, if the error message contains "Inappropriate ioctl for device", it now prints a user-friendly message advising to run the program in the terminal.

The modification involves simply wrapping the existing main function logic within a try-except structure:

```
try:
    # Existing main function logic here
except Exception as e:
    if 'Inappropriate ioctl for device' in str(e):
        print(colored('\n\nЗапустите программу в терминале! python3 main.py\n\n','red'))

```